### PR TITLE
fix HotReload

### DIFF
--- a/uweb3/__init__.py
+++ b/uweb3/__init__.py
@@ -326,15 +326,20 @@ class uWeb:
       port = self.config.options['development'].get('port', port)
       hotreload = self.config.options['development'].get('reload', False) in ('True', 'true')
       interval = int(self.config.options['development'].get('checkinterval', 0))
-      ignored_extensions = self.config.options['development'].get('ignored_extensions', '').split(',')
-      ignored_directories += self.config.options['development'].get('ignored_directories', '').split(',')
+      
+      ignored_extensions = []
+      if 'ignored_extensions' in self.config.options['development']:
+        ignored_extensions = self.config.options['development'].get('ignored_extensions').split(',')
+      if 'ignored_directories' in self.config.options['development']:
+        ignored_directories += self.config.options['development'].get('ignored_directories').split(',')
+
     server = make_server(host, int(port), self)
     print(f'Running µWeb3 server on http://{server.server_address[0]}:{server.server_address[1]}')
     print(f'Root dir is: {self.executing_path}')
     try:
       if hotreload:
         print(f'Hot reload is enabled for changes in: {self.executing_path}')
-        HotReload(self.executing_path, interval=interval, dev=dev,
+        HotReload(self.executing_path, interval=interval,
             ignored_extensions=ignored_extensions,
             ignored_directories=ignored_directories)
       server.serve_forever()


### PR DESCRIPTION
* remove unexpected keyword argument `dev` with call to `HotReload`

* add extra check for `ignored_extensions` and `ignored_directories`
  such it won't add an empty string to the lists as default