### PR TITLE
Add required dependency

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,7 +3,7 @@ uWeb was created by:
 - Jan Klopper <jan@underdar.nl>
 - Arjen Pander <arjen@underdark.nl>
 - Elmer de Looff <elmer.delooff@gmail.com>
-- Stef van Houten <stefvanhouten@gmail.com>
+- Stef van Houten <stef@underdark.nl>
 
 And has had code contributions from:
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ from setuptools import setup, find_packages
 
 REQUIREMENTS = [
     'PyMySQL',
-    'pytz'
+    'pytz',
+    'cryptography'
 ]
 
 def Description():


### PR DESCRIPTION
uWeb3 throws an 500 error when running the unittests from https://github.com/underdarknl/uweb3tests because the cryptography lib is missing. Installing this lib with pip >= 21.0 should solve the issue on Linux machines. However the cryptograpghy packages requires the Rust compiler to be installed on the machine, and for some reason this does currently not work(on Windows at least). 
https://cryptography.io/en/latest/installation/#rust