### PR TITLE
Support for ssl configs

### DIFF
--- a/uweb3/connectors/Mysql.py
+++ b/uweb3/connectors/Mysql.py
@@ -11,10 +11,12 @@ class Mysql(Connector):
   def __init__(self, config, options, request, debug=False):
     """Returns a MySQL database connection."""
     self.debug = debug
-    self.options = {'host': 'localhost',
-                   'user': None,
-                   'password': None,
-                   'database': ''}
+    self.options = {
+      'host': 'localhost',
+      'user': None,
+      'password': None,
+      'database': '',
+                   }
     try:
       from ..libs.sqltalk import mysql
       try:
@@ -27,6 +29,7 @@ class Mysql(Connector):
         passwd=self.options.get('password'),
         db=self.options.get('database'),
         charset=self.options.get('charset', 'utf8'),
+        ssl=options.get('ssl'),
         debug=self.debug)
     except Exception as e:
       raise ConnectionError('Connection to "%s" of type "%s" resulted in: %r' % (self.Name(), type(self), e))

--- a/uweb3/connectors/Mysql.py
+++ b/uweb3/connectors/Mysql.py
@@ -11,12 +11,10 @@ class Mysql(Connector):
   def __init__(self, config, options, request, debug=False):
     """Returns a MySQL database connection."""
     self.debug = debug
-    self.options = {
-      'host': 'localhost',
-      'user': None,
-      'password': None,
-      'database': '',
-                   }
+    self.options = {'host': 'localhost',
+                   'user': None,
+                   'password': None,
+                   'database': ''}
     try:
       from ..libs.sqltalk import mysql
       try:

--- a/uweb3/connectors/Mysql.py
+++ b/uweb3/connectors/Mysql.py
@@ -27,7 +27,11 @@ class Mysql(Connector):
         passwd=self.options.get('password'),
         db=self.options.get('database'),
         charset=self.options.get('charset', 'utf8'),
-        ssl=options.get('ssl'),
+        ssl_ca=self.options.get('ssl_ca'),
+        ssl_cert=self.options.get('ssl_cert'),
+        ssl_key=self.options.get('ssl_key'),
+        ssl_verify_cert=self.options.get('ssl_verify_cert'),
+        ssl_verify_identity=self.options.get('ssl_verify_identity'),
         debug=self.debug)
     except Exception as e:
       raise ConnectionError('Connection to "%s" of type "%s" resulted in: %r' % (self.Name(), type(self), e))


### PR DESCRIPTION
Can now add SSL certificates for the mysql connector. 

This can be placed in your base configuration. 
```
[ssl]
key = The path name of the client private key file.
cert = The path name of the client public key certificate file.
ca = The path name of the Certificate Authority (CA) certificate file. This option, if used, must specify the same certificate used by the server.
capath = The path name of the directory that contains trusted SSL CA certificate files.
cipher = The list of permissible ciphers for SSL encryption.
```
https://dev.mysql.com/doc/c-api/5.7/en/mysql-ssl-set.html