### PR TITLE
Allow passing uweb3 routes as Class.MethodName

### DIFF
--- a/uweb3/__init__.py
+++ b/uweb3/__init__.py
@@ -7,6 +7,7 @@ __version__ = '3.0.7'
 # Standard modules
 import configparser
 import datetime
+import importlib
 import logging
 import os
 import re
@@ -70,11 +71,10 @@ class Router:
       page_maker = None
       for pm in self.pagemakers:
         # Check if the page_maker has the method/handler we are looking for
-        try:
-          page_maker = details[0].__globals__[details[0].__qualname__.split('.')[0]]
+        if hasattr(details[0], '__call__'):
+          module = importlib.import_module(details[0].__module__)
+          page_maker = getattr(module, details[0].__qualname__.split('.', 1)[0])
           break
-        except:
-          pass
 
         if hasattr(pm, details[0]):
           page_maker = pm

--- a/uweb3/__init__.py
+++ b/uweb3/__init__.py
@@ -70,6 +70,12 @@ class Router:
       page_maker = None
       for pm in self.pagemakers:
         # Check if the page_maker has the method/handler we are looking for
+        try:
+          page_maker = details[0].__globals__[details[0].__qualname__.split('.')[0]]
+          break
+        except:
+          pass
+
         if hasattr(pm, details[0]):
           page_maker = pm
           break
@@ -330,7 +336,11 @@ class uWeb:
         # We're specifically calling _StaticPostInit here as promised in documentation, seperate from the regular PostInit to keep things fast for static pages
         page_maker._StaticPostInit()
 
+
       # pylint: enable=W0212
+      if not isinstance(method, str):
+        return method(page_maker, *args)
+
       return getattr(page_maker, method)(*args)
     except pagemaker.ReloadModules as message:
       reload_message = reload(sys.modules[self.initial_pagemaker.__module__])


### PR DESCRIPTION
Allows an alternative way of passing route handlers to uweb3. 
This also makes it possible to have routes with the same name but different implementations depending on the pagemaker.

![image](https://user-images.githubusercontent.com/15339728/162576535-7753f07b-7209-457b-b066-63dedf89b9e5.png)

![image](https://user-images.githubusercontent.com/15339728/162576652-5abc7178-af91-4a5e-ab2c-69915690fcac.png)