### PR TITLE
Optional autocommit

### DIFF
--- a/uweb3/connections.py
+++ b/uweb3/connections.py
@@ -162,11 +162,15 @@ class ConnectionManager(object):
     Eg, connections that rely on request information, or connections that should
     not be kept alive beyond the scope of a request.
     """
-    cleanups = [
-        classname for classname in self.__connections
-        if (hasattr(self.__connections[classname], 'PERSISTENT')
-            and not self.__connections[classname].PERSISTENT)
-    ]
+    cleanups = []
+    for classname in self.__connections:
+      if (hasattr(self.__connections[classname], 'PERSISTENT') and not self.__connections[classname].PERSISTENT):
+        cleanups.append(classname)
+      else:
+        connector = self.__connections[classname]
+        if len(connector.connection.queries) != 0:
+          connector.Rollback()
+
     for classname in cleanups:
       try:
         self.__connections[classname].Disconnect()

--- a/uweb3/connectors/Mysql.py
+++ b/uweb3/connectors/Mysql.py
@@ -54,8 +54,7 @@ class Mysql(Connector):
       print('Rolling back uncommited transaction on Mysql connector')
 
     with self.connection as cursor:
-      return cursor.rollback()
-      # return cursor.Execute("ROLLBACK")
+      return cursor.Execute("ROLLBACK")
 
   def Disconnect(self):
     """Closes the MySQL connection."""

--- a/uweb3/connectors/Mysql.py
+++ b/uweb3/connectors/Mysql.py
@@ -50,8 +50,12 @@ class Mysql(Connector):
     return ssl
 
   def Rollback(self):
+    if self.debug:
+      print('Rolling back uncommited transaction on Mysql connector')
+
     with self.connection as cursor:
-      return cursor.Execute("ROLLBACK")
+      return cursor.rollback()
+      # return cursor.Execute("ROLLBACK")
 
   def Disconnect(self):
     """Closes the MySQL connection."""

--- a/uweb3/connectors/Sqlite.py
+++ b/uweb3/connectors/Sqlite.py
@@ -22,6 +22,9 @@ class Sqlite(Connector):
 
   def Rollback(self):
     """Rolls back any uncommited transactions."""
+    if self.debug:
+      print('Rolling back uncommited transaction on Mysql connector')
+
     return self.connection.rollback()
 
   def Disconnect(self):

--- a/uweb3/libs/sqltalk/mysql/connection.py
+++ b/uweb3/libs/sqltalk/mysql/connection.py
@@ -162,7 +162,7 @@ class Connection(pymysql.connections.Connection):
     if self.lock.acquire():  # This will block when the lock is in use. In normal situations this should never happen.
       self.counter_transactions += 1
       del self.queries[:]
-      self._SetAutocommitState(self.autocommit)
+      self._SetAutocommitState(self.autocommit_mode)
       self.StartTransactionTimer()
       return cursor.Cursor(self)
     raise self.OperationalError(

--- a/uweb3/libs/sqltalk/mysql/connection.py
+++ b/uweb3/libs/sqltalk/mysql/connection.py
@@ -190,6 +190,10 @@ class Connection(pymysql.connections.Connection):
                             self.get_host_info())
     self.lock.release()
 
+  def commit(self):
+    super().commit()
+    del self.queries[:]
+
   def rollback(self):
     super().rollback()
     if self.debug:

--- a/uweb3/libs/sqltalk/mysql/connection.py
+++ b/uweb3/libs/sqltalk/mysql/connection.py
@@ -165,7 +165,8 @@ class Connection(pymysql.connections.Connection):
     if self.lock.acquire(
     ):  # This will block when the lock is in use. In normal situations this should never happen.
       self.counter_transactions += 1
-      del self.queries[:]
+      if self.autocommit_mode:
+        del self.queries[:]
       self._SetAutocommitState(self.autocommit_mode)
       self.StartTransactionTimer()
       return cursor.Cursor(self)

--- a/uweb3/libs/sqltalk/mysql/connection.py
+++ b/uweb3/libs/sqltalk/mysql/connection.py
@@ -97,7 +97,7 @@ class Connection(pymysql.connections.Connection):
     if kwargs.pop('disable_log', False):
       self.logger.disable_logger = True
 
-    autocommit = kwargs.pop('autocommit', None)
+    autocommit = kwargs.pop('autocommit', True)
     charset = kwargs.pop('charset', 'utf8')
     sql_mode = kwargs.pop('sql_mode', None)
 

--- a/uweb3/libs/sqltalk/sqlite/connection.py
+++ b/uweb3/libs/sqltalk/sqlite/connection.py
@@ -31,6 +31,7 @@ class Connection(sqlite3.Connection):
       self.logger.setLevel(logging.WARNING)
     if kwds.pop('disable_log', False):
       self.logger.disable_logger = True
+    self.autocommit_mode = kwds.pop('autocommit', True)
     sqlite3.Connection.__init__(self, *args, **kwds)
 
   def __enter__(self):
@@ -43,7 +44,7 @@ class Connection(sqlite3.Connection):
     if exc_type:
       self.rollback()
       self.logger.warning('Transaction was rolled back.')
-    else:
+    elif self.autocommit_mode:
       self.commit()
       self.logger.debug('Transaction committed.')
 


### PR DESCRIPTION
It is now possible to turn off autocommit on the connection object. 

![image](https://user-images.githubusercontent.com/15339728/164888911-4dd044f0-8395-4159-b938-d3de895203d3.png)

If at the end of a non-persistent request there are still uncommited queries in a transaction the transaction will be rolled back. 
This brings the side effect of having dirty reads when using the same connection object without manually commits when autocommit is turned off. 