### PR TITLE
Allow template_alias when loading inline file

### DIFF
--- a/uweb3/templateparser.py
+++ b/uweb3/templateparser.py
@@ -632,7 +632,7 @@ class FileTemplate(Template):
     self.ReloadIfModified()
     try:
       if self._template_alias:
-        kwds = {'__filename': self._template_alias, **kwds}
+        kwds = {'__alias': self._template_alias, **kwds}
       result = super().Parse(**kwds)
     except TemplateFunctionError as error:
       raise TemplateFunctionError('%s in %s' % (error, self._template_path))


### PR DESCRIPTION
Allows user to re-use template with an alias. 
This can be used to re-use an error message template on multiple places on the same page by putting the error messages in a dictionary with the template alias as key. 

![image](https://user-images.githubusercontent.com/15339728/165957883-ca35ca3c-d7b7-4bbd-9b4f-752922d3e832.png)
![image](https://user-images.githubusercontent.com/15339728/165958206-a52ddc20-b760-433c-8d86-fc13bd55b63c.png)
