### PR TITLE
Fix for mail lib not working propperly

### DIFF
--- a/uweb3/libs/safestring/__init__.py
+++ b/uweb3/libs/safestring/__init__.py
@@ -299,7 +299,10 @@ class EmailAddresssafestring(Basesafestring):
         ([a-zA-Z0-9.-]+) # domain name
         (\.[a-zA-Z]{2,4}) # dot-something
     )''', re.VERBOSE)
-    return regex.search(data).group()
+    result = regex.search(data)
+    if result:
+      return result.group()
+    return ''
 
   def unescape(self, data):
     """Can't unremove non address elements so we'll just return the string"""


### PR DESCRIPTION
Mailing attachments now works properly again, I think it might have had something to do with the wrap function that was used in attachments.

Small fix for EmailAddresssafestring, this now returns an empty string when no regex group can be found to prevent errors while parsing.  