### PR TITLE
If a templatetag has a function evaluate that function and add it to …

### DIFF
--- a/uweb3/templateparser.py
+++ b/uweb3/templateparser.py
@@ -729,6 +729,9 @@ class TemplateConditional(object):
     local_vars = LazyTagValueRetrieval(kwds)
     for num, node in enumerate(expr):
       if isinstance(node, TemplateTag):
+        if node.functions:
+          nodes.append(node.Parse(**kwds))
+          continue
         node_name = '__tmpl_var_%d' % num
         local_vars[node_name] = node
         nodes.append(node_name)
@@ -793,7 +796,7 @@ class TemplateConditionalNotPresence(TemplateConditionalPresence):
     """Checks the presence of all tags named on the branch."""
     try:
       for tag in tags:
-        f
+        tag.GetValue(kwds)
       return False
     except (TemplateKeyError, TemplateNameError):
       return True


### PR DESCRIPTION
Currently when attempting to use a templatefunction in an if statement the function is totally ignored and the value of the tag itself is returned instead. 
This should fix that issue by checking if the tag has functions present, and if this is the case the tag is parsed and the result is used in the evaluation of the condition. 

All templateparser unittests passed after this chage. 