### PR TITLE
External inline template tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def Version():
     """Returns the version of the library as read from the __init__.py file"""
     main_lib = os.path.join(os.path.dirname(__file__), "uweb3", "__init__.py")
     with open(main_lib) as v_file:
-        return re.match(".*__version__ = '(.*?)'", v_file.read(), re.S).group(1)
+        return re.match(".*__version__ = \"(.*?)\"", v_file.read(), re.S).group(1)
 
 
 setup(

--- a/test/test_templateparser.py
+++ b/test/test_templateparser.py
@@ -6,11 +6,11 @@
 
 # Standard modules
 import os
-import shutil
-from pathlib import Path
 import re
+import shutil
 import time
 import unittest
+from pathlib import Path
 
 # Unittest target
 from uweb3 import templateparser
@@ -1253,7 +1253,7 @@ class TestExternalInline(unittest.TestCase):
             f.write(
                 """
                 hello from test.html
-                {{ externalinline app_two/templates/another_template.html }}                    
+                {{ externalinline app_two/templates/another_template.html }}
                 """
             )
 
@@ -1270,7 +1270,7 @@ class TestExternalInline(unittest.TestCase):
         file, _ = self._create_basic_files()
         result = self.parser.Parse(str(file))
         expected = """hello from test.html
-                hello from another_template                   
+                hello from another_template
                 """
 
         self.assertEqual(str(result).strip(), expected.strip())
@@ -1299,7 +1299,7 @@ class TestExternalInline(unittest.TestCase):
             f.write(
                 """
                 hello from test.html
-                {{ inline app_two/templates/another_template.html }}                    
+                {{ inline app_two/templates/another_template.html }}
                 """
             )
 
@@ -1320,7 +1320,7 @@ class TestExternalInline(unittest.TestCase):
             f.write(
                 """
                 hello from test.html
-                {{ externalinline app_two/../another_template.html }}                    
+                {{ externalinline app_two/../another_template.html }}
                 """
             )
 
@@ -1382,7 +1382,7 @@ class TestExternalInline(unittest.TestCase):
             f.write(
                 """hello from test.html
                 {{ externalinline app_two/templates/another_template.html }}
-                {{ inline local_file.html }}               
+                {{ inline local_file.html }}
                 """
             )
 

--- a/uweb3/logger.py
+++ b/uweb3/logger.py
@@ -1,7 +1,6 @@
 import logging
 from typing import NamedTuple
 
-
 from uweb3.request import IndexedFieldStorage
 
 DEBUG_FORMAT = (

--- a/uweb3/pagemaker/__init__.py
+++ b/uweb3/pagemaker/__init__.py
@@ -8,6 +8,7 @@ import logging
 import mimetypes
 import os
 import pyclbr
+from re import template
 import sys
 import threading
 import time
@@ -204,13 +205,18 @@ class Base:
         Otherwise, the `TEMPLATE_DIR` will be used to load templates from.
         """
         if "__parser" not in self.persistent:
+            allowed_paths = self.options.get("templates", {}).get("allowed_paths", "")
+            allowed_paths_tuple = tuple(allowed_paths.replace(" ", "").split(","))
+            
             self.persistent.Set(
                 "__parser",
                 templateparser.Parser(
-                    self.options.get("templates", {}).get("path", self.TEMPLATE_DIR)
+                    self.options.get("templates", {}).get("path", self.TEMPLATE_DIR),
+                    allowed_paths=allowed_paths_tuple,
                 ),
             )
-        parser = self.persistent.Get("__parser")
+        parser: templateparser.Parser = self.persistent.Get("__parser")
+        parser.template_dir = self.TEMPLATE_DIR
         parser.dictoutput = self.req.noparse
         return parser
 

--- a/uweb3/pagemaker/__init__.py
+++ b/uweb3/pagemaker/__init__.py
@@ -213,6 +213,7 @@ class Base:
                 templateparser.Parser(
                     self.options.get("templates", {}).get("path", self.TEMPLATE_DIR),
                     allowed_paths=allowed_paths_tuple,
+                    executing_path=self.LOCAL_DIR,
                 ),
             )
         parser: templateparser.Parser = self.persistent.Get("__parser")

--- a/uweb3/pagemaker/__init__.py
+++ b/uweb3/pagemaker/__init__.py
@@ -8,23 +8,23 @@ import logging
 import mimetypes
 import os
 import pyclbr
-from re import template
 import sys
 import threading
 import time
 from base64 import b64encode
+from re import template
 
 import magic
 from pymysql import Error as pymysqlerr
 
 import uweb3
 from uweb3.logger import (
+    DebuggingDetails,
+    UwebDebuggingAdapter,
+    default_data_scrubber,
     setup_debug_logger,
     setup_debug_stream_logger,
     setup_error_logger,
-    UwebDebuggingAdapter,
-    DebuggingDetails,
-    default_data_scrubber,
 )
 from uweb3.request import IndexedFieldStorage
 
@@ -207,7 +207,7 @@ class Base:
         if "__parser" not in self.persistent:
             allowed_paths = self.options.get("templates", {}).get("allowed_paths", "")
             allowed_paths_tuple = tuple(allowed_paths.replace(" ", "").split(","))
-            
+
             self.persistent.Set(
                 "__parser",
                 templateparser.Parser(

--- a/uweb3/response.py
+++ b/uweb3/response.py
@@ -2,10 +2,7 @@
 """uWeb3 response classes."""
 
 # Standard modules
-try:
-    import httplib
-except ImportError:
-    import http.client as httplib
+import http.client as httplib
 
 
 class Response(object):

--- a/uweb3/templateparser.py
+++ b/uweb3/templateparser.py
@@ -22,7 +22,6 @@ import os
 import re
 from typing import Any, Callable, Tuple, Union
 
-from pyparsing import Mapping
 
 from .libs.safestring import (
     Basesafestring,

--- a/uweb3/templateparser.py
+++ b/uweb3/templateparser.py
@@ -213,6 +213,7 @@ class Parser(dict):
         dictoutput=False,
         templateEncoding="utf-8",
         allowed_paths=(),
+        executing_path=None,
     ):
         """Initializes a Parser instance.
 
@@ -231,6 +232,7 @@ class Parser(dict):
         """
         super().__init__()
         self.template_dir = path
+        self.executing_path = executing_path
         self.dictoutput = dictoutput
         self.allowed_paths = allowed_paths
         self.tags = {}

--- a/uweb3/templateparser.py
+++ b/uweb3/templateparser.py
@@ -234,7 +234,12 @@ class Parser(dict):
         self.template_dir = path
         self.executing_path = executing_path
         self.dictoutput = dictoutput
-        self.allowed_paths = allowed_paths
+        
+        if self.template_dir:
+            self.allowed_paths = (self.template_dir,) + allowed_paths
+        else:
+            self.allowed_paths = allowed_paths
+            
         self.tags = {}
         self.requesttags = {}
         self.astvisitor = AstVisitor(EVALWHITELIST)

--- a/uweb3/templateparser.py
+++ b/uweb3/templateparser.py
@@ -359,12 +359,8 @@ class Parser(dict):
                 )
         else:
             template_path = location
-        try:
-            self[name or location] = FileTemplate(
-                template_path, parser=self, encoding=None
-            )
-        except IOError:
-            raise TemplateReadError("Could not load template %r" % template_path)
+
+        return self.CreateFileTemplate(location, template_path, name=name)
 
     def Parse(self, template, **replacements):
         """Returns the referenced template with its tags replaced by **replacements.

--- a/uweb3/templateparser.py
+++ b/uweb3/templateparser.py
@@ -600,6 +600,15 @@ class Template(list):
 
     def AddExternal(self, name):
         """Allows loading in external files from directories outside of the
+        current templateparser template_dir. 
+        
+        When using {{ externalinline }} allowed_paths must be provided to the
+        templateparser. 
+        
+        Arguments:
+            name (str): Relative path seen to the executing path of the project. 
+        """
+        self.name = os.path.join(self.parser.executing_path, name)
         if self.parser is None:
             raise TypeError("The template requires parser for adding template files.")
 

--- a/uweb3/templateparser.py
+++ b/uweb3/templateparser.py
@@ -351,9 +351,10 @@ class Parser(dict):
         """
         if self.template_dir:
             template_path = os.path.realpath(os.path.join(self.template_dir, location))
-            if self.template_dir != os.path.commonprefix(
+            prefix = os.path.commonprefix(
                 (template_path, self.template_dir)
-            ):
+            )
+            if self.template_dir != prefix:
                 raise TemplateReadError(
                     "Could not load template %r, not in template dir" % template_path
                 )

--- a/uweb3/templateparser.py
+++ b/uweb3/templateparser.py
@@ -266,6 +266,30 @@ class Parser(dict):
             self.AddTemplate(template)
         return super().__getitem__(template)
 
+    def CreateFileTemplate(self, location, template_path, name=None, path=None):
+        if path:
+            try:
+                self[name or location] = FileTemplate(
+                    template_path,
+                    parser=Parser(
+                        path=path,
+                        allowed_paths=self.allowed_paths,
+                        dictoutput=self.dictoutput,
+                        templateEncoding=self.templateEncoding,
+                        executing_path=self.executing_path,
+                    ),
+                    encoding=None,
+                )
+            except IOError:
+                raise TemplateReadError("Could not load template %r" % template_path)
+        else:
+            try:
+                self[name or location] = FileTemplate(
+                    template_path, parser=self, encoding=None
+                )
+            except IOError:
+                raise TemplateReadError("Could not load template %r" % template_path)
+
     def AddExternal(self, location, name=None):
         if location in self:
             return super().__getitem__(location)

--- a/uweb3/templateparser.py
+++ b/uweb3/templateparser.py
@@ -234,12 +234,12 @@ class Parser(dict):
         self.template_dir = path
         self.executing_path = executing_path
         self.dictoutput = dictoutput
-        
+
         if self.template_dir:
             self.allowed_paths = (self.template_dir,) + allowed_paths
         else:
             self.allowed_paths = allowed_paths
-            
+
         self.tags = {}
         self.requesttags = {}
         self.astvisitor = AstVisitor(EVALWHITELIST)
@@ -300,8 +300,10 @@ class Parser(dict):
             return super().__getitem__(location)
 
         if not self.allowed_paths:
-            raise TemplateReadError("Externalinline is not allowed without specifying allowed_paths.")
-        
+            raise TemplateReadError(
+                "Externalinline is not allowed without specifying allowed_paths."
+            )
+
         if self.template_dir:
             for path in self.allowed_paths:
                 template_path = os.path.realpath(os.path.join(path, location))
@@ -336,9 +338,7 @@ class Parser(dict):
         """
         if self.template_dir:
             template_path = os.path.realpath(os.path.join(self.template_dir, location))
-            prefix = os.path.commonprefix(
-                (template_path, self.template_dir)
-            )
+            prefix = os.path.commonprefix((template_path, self.template_dir))
             if self.template_dir != prefix:
                 raise TemplateReadError(
                     "Could not load template %r, not in template dir" % template_path
@@ -582,13 +582,13 @@ class Template(list):
 
     def AddExternal(self, name):
         """Allows loading in external files from directories outside of the
-        current templateparser template_dir. 
-        
+        current templateparser template_dir.
+
         When using {{ externalinline }} allowed_paths must be provided to the
-        templateparser. 
-        
+        templateparser.
+
         Arguments:
-            name (str): Relative path seen to the executing path of the project. 
+            name (str): Relative path seen to the executing path of the project.
         """
         self.name = os.path.join(self.parser.executing_path, name)
         if self.parser is None:

--- a/uweb3/templateparser.py
+++ b/uweb3/templateparser.py
@@ -599,8 +599,7 @@ class Template(list):
         return self._AddToOpenScope(self.parser[name])
 
     def AddExternal(self, name):
-        self.name = os.path.abspath(name)
-
+        """Allows loading in external files from directories outside of the
         if self.parser is None:
             raise TypeError("The template requires parser for adding template files.")
 


### PR DESCRIPTION
Better solution for https://github.com/underdarknl/uweb3/pull/50.

This allows loading templates from template directories outside of the current parsers template directory.
This requires adding allowed paths to the config file:

```
[templates] 
allowed_paths = absolute_path_to_allowed_folder, ...
```
This allows the following syntax in templates in a project structure like this:
```
/home/devel/project/workingdir/app/templates/index.html
/home/devel/project/workingdir/app/templates/local_template.html
/home/devel/project/workingdir/another_app/templates/external_template.html
```

> index.html
```
<p>hello</p>
{{ inline local_template.html }} 
{{ externalinline another_app/templates/external_template.html
```

When an externalinline tag is parsed a new parser instance will be created for the given tag.
This allows the external template to parse all ```{{ inline }}``` tags correctly.
This also makes it possible to use nested ```{{ externalinline }}``` tags, bouncing between allowed folders. 

### Issues
Currently it is not possible to use ```parser.RegisterTag``` to create a tag like [header] that loads the header file from a path that is different from the current parsers template_dir. This is because the RegisterTag uses the regular AddTemplate method, which does not allow loading templates that are outside the template_dir.
However you could just use ```{{ externalinline path/to/header.html }}```. 
