### PR TITLE
Record values failed save

### DIFF
--- a/test/test_model.py
+++ b/test/test_model.py
@@ -284,6 +284,18 @@ class RecordTests(unittest.TestCase):
             model.NotExistError, Author.FromPrimary, self.connection, new_author.key
         )
 
+    def testFailedUpdate(self):
+        """Author_two's values should default back to the original record stored
+        values after the update has failed."""
+        Author.Create(self.connection, {"name": "W. Shakespeare"})
+        author_two = Author.Create(self.connection, {"name": "W. Shakespeare"})
+        author_two.update({"ID": 1})
+        try:
+            author_two.Save()
+        except self.connection.IntegrityError:
+            pass
+        self.assertDictEqual(dict(author_two), {"ID": 2, "name": "W. Shakespeare"})
+
 
 class NonStandardTableAndRelations(unittest.TestCase):
     """Verified autoloading works for records with an alternate table name."""

--- a/uweb3/model.py
+++ b/uweb3/model.py
@@ -1213,10 +1213,15 @@ class Record(BaseRecord):
         """
         self._PreSave(cursor)
         difference = self._Changes()
-        if difference:
-            self._RecordUpdate(cursor)
-            self._record.update(difference)
-        self._PostSave(cursor)
+        try:
+            if difference:
+                self._RecordUpdate(cursor)
+                self._record.update(difference)
+            self._PostSave(cursor)
+        except Exception as exc:
+            # After a failed save rollback the record to the stored database values
+            self.update(self._record)
+            raise exc
 
     # ############################################################################
     # Public methods for creation, deletion and storing Record objects.


### PR DESCRIPTION
This change prevents that a record stays in an invalid state after the `record.Save()` failed.
This prevents having to re-fetch the actual record from the database in order to show the correct page to the user.

E.g: 
- User attempts to update record but fails
- Local record dictionary is still updated and thus no longer accurately represents the stored record values (this is expected behavior when editing a record before saving). 
- User page will now show data as if record was updated (because the local value did not rollback to the stored value).