### PR TITLE
Update regex for template functions to not break on different formatting

### DIFF
--- a/uweb3/templateparser.py
+++ b/uweb3/templateparser.py
@@ -447,7 +447,7 @@ class Parser(dict):
 class Template(list):
     """Contained for template parts, allowing for rich content construction."""
 
-    FUNCTION = re.compile(r"\{\{\s*(.*?)\s*\}\}")
+    FUNCTION = re.compile(r"\{\{\s*([\s\S]*?)\s*\}\}")
     # For a full tag syntax explanation, refer to the TAG regex in TemplateTag.
     TAG = re.compile(
         """


### PR DESCRIPTION
Allow the template parser to match template functions that contain a newline between the condition and the value. 
This change allows more convenient formatting on longer statements. 

For example the current regex does not match: 
![image](https://user-images.githubusercontent.com/15339728/184603746-bc488d45-8bfe-4db0-8894-fe57fc217f35.png)

While the new regex will match: 
![image](https://user-images.githubusercontent.com/15339728/184603824-aaf959ae-186a-4551-8ee9-58bd85658279.png)
